### PR TITLE
Add kill switch for interactive/live

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -10,6 +10,7 @@ pub(crate) const UJ_TO_J_FACTOR: f64 = 1000000.;
 const COLOUR_BLACK: i16 = 0;
 const DEFAULT_COLOUR: i16 = -1;
 pub(crate) const HEADER_PAIR: i16 = 1;
+pub(crate) const KEY_CODE_EXIT: i32 = 113;  // q
 
 pub(crate) fn read_power(file_path: String) -> f64 {
     let power = fs::read(format!("{}/energy_uj", file_path.to_owned())).expect(format!("Couldn't read file {}/energy_uj", file_path.to_owned()).as_str());
@@ -187,8 +188,9 @@ pub(crate) fn setup_rapl_data() -> Vec<models::RAPLData> {
 }
 
 pub(crate) fn setup_ncurses() {
-    ncurses::initscr();
+    let w = ncurses::initscr();
     ncurses::curs_set(ncurses::CURSOR_VISIBILITY::CURSOR_INVISIBLE);
+    ncurses::nodelay(w, true);
 
     if ncurses::has_colors() {
         ncurses::start_color();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -20,8 +20,6 @@ pub(crate) fn live_measurement(poll_delay: u64) {
     #[allow(unused_assignments)]
     let mut now = start_time;
 
-    print_headers!(true);
-
     loop {
         now = Instant::now();
         for zone in zones {
@@ -55,9 +53,15 @@ pub(crate) fn live_measurement(poll_delay: u64) {
         new_zones.clear();
 
         ncurses::clear();
+        ncprint!("Press 'q' to quit\n");
         print_result_line!(&zones, true);
 
         prev_time = now;
+
+        if ncurses::getch() == common::KEY_CODE_EXIT {
+            ncurses::endwin();
+            break;
+        }
 
         thread::sleep(sleep);
     }
@@ -112,7 +116,7 @@ pub(crate) fn benchmark_interactive(program: PathBuf, poll_delay: u64) {
     #[allow(unused_assignments)]
     let mut now = start_time;
 
-    let _out = Command::new(program.to_owned()).spawn().expect("Failed to execute command");
+    let _out = Command::new(program.to_owned()).spawn().expect("Couldn't execute command");
 
     loop {
         now = Instant::now();
@@ -147,10 +151,16 @@ pub(crate) fn benchmark_interactive(program: PathBuf, poll_delay: u64) {
         new_zones.clear();
 
         ncurses::clear();
-        ncprint!(format!("Running application {:?}. Ctrl+C to exit. Exiting will kill {:?} as well\n", program, program).as_str());
+        ncprint!(format!("Running application {:?}\n", program).as_str());
+        ncprint!(format!("'q' or ctrl+c to exit. Ctrl+c will kill {:?} as well\n", program).as_str());
         print_result_line!(&zones, true);
 
         prev_time = now;
+
+        if ncurses::getch() == common::KEY_CODE_EXIT {
+            ncurses::endwin();
+            break;
+        }
 
         thread::sleep(sleep);
     }


### PR DESCRIPTION
Added a kill switch for `interactive` and `live`. For `interactive` it won't kill the subprocess as well, like ctrl+c will.

Resolves #7