### PR TITLE
Log poll results to persistent storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 [dependencies]
 structopt = "0.3.23"
 ncurses = "5.101.0"
+csv = "1.1"
+serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Scripts are located in `./benchmarks/`. We discern between three types:
 - `macro`: larger benchmarks that perform several tasks. TBA, `./benchmark/macro`
 - `micro`: smaller benchmarks that perform a single task. `./benchmark/micro`
 
+### CSV output
+`raplrs` outputs data from each poll in `csv` format. Sample output:
+
+```
+zone        time elapsed (s)    power used (joules)     avg watt usage          avg watt usage since last poll  start power (joules)    previous power          previous power reading
+package-0,  28.030436537,       517.9944529999993,      18.479764219175102,     17.634610487045965,             14719.149051,           500.34430299999985,     15237.143504
+core,       28.030548686,       364.91492099999596,     13.01855967970924,      11.588462316530928,             55951.045459,           353.3162470000025,      56315.96038
+uncore,     28.030660372,       39.756702999999106,     1.4183443342235091,     2.070532459219232,              4492.606319,            37.684346000000005,     4532.363022
+```
+
 ## Usage
 ```
 $ sudo ./raplrs 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,24 @@
+use crate::models;
+
+use csv;
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::fs::OpenOptions;
+use std::path::Path;
+
+pub(crate) fn log_poll_result(system_start_time: SystemTime, tool: String, zone: models::RAPLData) {
+    let file_name = format!("{}-{}.csv", tool, system_start_time.duration_since(UNIX_EPOCH)
+        .expect("Failed to check duration").as_secs_f64());
+
+    if Path::new(file_name.to_owned().as_str()).exists() {
+        let file = OpenOptions::new().write(true).append(true).open(file_name).unwrap();
+
+        let mut wtr = csv::WriterBuilder::default().has_headers(false).from_writer(file);
+        wtr.serialize(zone).expect("Failed to write to file");
+    } else {
+        let file = OpenOptions::new().write(true).create(true).open(file_name).unwrap();
+
+        let mut wtr = csv::Writer::from_writer(file);
+        wtr.serialize(zone).expect("Failed to write to file");
+    }
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 #[macro_use] mod common;
 mod tools;
 mod models;
+mod logger;
 
 use structopt::StructOpt;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 #[derive(StructOpt)]
 #[structopt(
@@ -57,17 +59,18 @@ enum Cli {
 }
 
 fn main() {
+    let system_start_time = SystemTime::now();
     match Cli::from_args() {
         Cli::Live { delay } => {
             common::setup_ncurses();
-            tools::live_measurement(delay);
+            tools::live_measurement(delay, system_start_time);
         },
         Cli::Benchmark { runner, program, args, n} => {
             tools::benchmark(runner, program, args, n);
         },
         Cli::BenchmarkInt { program, delay } => {
             common::setup_ncurses();
-            tools::benchmark_interactive(program, delay);
+            tools::benchmark_interactive(program, delay, system_start_time);
         },
         Cli::Inline { metric, delay } => {
             tools::inline(metric, delay);

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,5 @@
+use serde;
+use serde::Serialize;
 
 #[derive(Debug)]
 pub(crate) struct RAPLZone {
@@ -5,8 +7,9 @@ pub(crate) struct RAPLZone {
     pub name: String
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct RAPLData {
+    #[serde(skip_serializing)]
     pub path: String,
     pub zone: String,
     pub time_elapsed: f64,


### PR DESCRIPTION
Resolves #2

This PR implements logging of each poll results during measurements. All results are stored in `csv` and I included a sample in `README.md`.

For now this is only implemented for `live` and `benchmark-int`. While `benchmark` is still missing, this is added as an issue: #19 