### PR TITLE
Add interval option for benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Benchmark a single, oneshot program, optionally `n` times. If `-n` is passed, `n
 By default, `benchmark` expects `<program>` to be executable - alternatively you can specify a runner, e.g., `bash`, with `-r, --runner`.
 Additionally, `benchmark` expects `<program>` to terminate on its own - if this is not the case for your benchmark, see [`benchmark-int`](#benchmark-int).
 
+To allow a cooldown period between benchmarks, specify an interval in seconds with `-i, --interval`.
+
 ```
 raplrs-benchmark 0.1.0
 Measure power consumption of a oneshot script
@@ -181,6 +183,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
+    -i, --interval <interval>    Interval between benchmark runs in seconds [default: 0]
     -n <n>                   Amount of times to run benchmark [default: 1]
     -r, --runner <runner>    Benchmark requires <runner> to execute
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,10 @@ enum Tool {
         args: Vec<String>,
         /// Amount of times to run benchmark
         #[structopt(short = "n", default_value = "1")]
-        n: u64
+        n: u64,
+        /// Interval between benchmark runs in seconds
+        #[structopt(short = "i", long = "interval", default_value = "0")]
+        interval: u64
     },
     #[structopt(about = "Measure power consumption of an interactive application")]
     BenchmarkInt {
@@ -92,8 +95,8 @@ fn main() {
             common::setup_ncurses();
             tools::live_measurement(args_.delay, system_start_time, args_.run_time_limit, name);
         },
-        Tool::Benchmark { runner, program, args, n } => {
-            tools::do_benchmarks(args_.delay, runner, program, args, n, name, args_.isolate_file);
+        Tool::Benchmark { runner, program, args, n, interval } => {
+            tools::do_benchmarks(args_.delay, runner, program, args, n, name, args_.isolate_file, interval);
         },
         Tool::BenchmarkInt { runner, program, background_log } => {
             if !background_log {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -55,7 +55,8 @@ pub(crate) fn live_measurement(poll_delay: u64, system_start_time: SystemTime, r
 }
 
 pub(crate) fn do_benchmarks(poll_delay: u64, runner: Option<PathBuf>, program: PathBuf, args: Vec<String>,
-                            n: u64, name: String, isolate_file: Option<PathBuf>) {
+                            n: u64, name: String, isolate_file: Option<PathBuf>, interval: u64) {
+    let sleep = Duration::from_secs(interval);
     for i in 0..n {
         if n > 1 {
             println!("Running benchmark iteration {}", i + 1);
@@ -63,6 +64,11 @@ pub(crate) fn do_benchmarks(poll_delay: u64, runner: Option<PathBuf>, program: P
 
         benchmark(poll_delay, runner.to_owned(), program.to_owned(),
                   args.to_owned(), name.to_owned(), isolate_file.to_owned());
+
+        if interval > 0 && i + 1 < n {
+            println!("Sleeping for {} seconds before next benchmark run", interval);
+            thread::sleep(sleep);
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds `-i, --interval` to `benchmark`, allowing the user to specify an interval (that is, a cooldown period) between benchmarks, in seconds.