### PR TITLE
Receive with timeout to avoid busy waiting

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-gnu"

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use crate::common;
-use crate::models;
 
 use std::thread;
 use std::time::{Instant, SystemTime};
 use std::thread::JoinHandle;
 use std::sync::mpsc::Receiver;
 use crate::models::IsolateData;
+use std::time::Duration;
 
 pub(crate) fn spawn_measurement_thread(start_time: Instant, system_start_time: SystemTime,
                                        recv: Receiver<i8>, poll_delay: u64, tool_name: String,
@@ -14,13 +14,13 @@ pub(crate) fn spawn_measurement_thread(start_time: Instant, system_start_time: S
                                        isolate_map: Option<HashMap<String, IsolateData>>) -> JoinHandle<()> {
     let thr = thread::spawn(move || {
         let mut tzones = common::setup_rapl_data().to_owned();
-        let mut thread_zones: Vec<models::RAPLData> = vec![];
         let mut prev_time = start_time.to_owned();
         // reassign locally - unsafe otherwise
         let trecv = recv;
         let mut run = true;
         #[allow(unused_assignments)]
         let mut now = Instant::now();
+        let duration = Duration::from_millis(poll_delay);
 
         while run {
             now = Instant::now();
@@ -28,25 +28,19 @@ pub(crate) fn spawn_measurement_thread(start_time: Instant, system_start_time: S
                 tzones.to_owned(), now, start_time, prev_time, system_start_time,
                 tool_name.to_owned(), benchmark_name.to_owned(), isolate_map.to_owned()
             );
-            thread_zones.clear();
             prev_time = now;
 
-            let sleep_from = Instant::now();
-            while sleep_from.elapsed().as_millis() < poll_delay as u128 {
-                match trecv.try_recv() {
-                    Ok(msg) => {
-                        if msg == common::THREAD_KILL {
-                            let now = Instant::now();
-                            let _ = common::update_measurements(
-                                tzones.to_owned(), now, start_time, prev_time, system_start_time,
-                                tool_name.to_owned(), benchmark_name.to_owned(), isolate_map.to_owned()
-                            );
-                            run = false;
-                            break;
-                        }
-                    },
-                    Err(_) => {}
-                }
+            match trecv.recv_timeout(duration) {
+                Ok(msg) => {
+                    if msg == common::THREAD_KILL {
+                        let now = Instant::now();
+                        let _ = common::update_measurements(
+                            tzones.to_owned(), now, start_time, prev_time, system_start_time,
+                            tool_name.to_owned(), benchmark_name.to_owned(), isolate_map.to_owned()
+                        );
+                        run = false;                    }
+                },
+                Err(_) => {}
             }
         }
     });


### PR DESCRIPTION
This PR changes from receiving with [try_recv](https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.try_recv) to receiving with [recv_timeout](https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.recv_timeout).

This avoid busy waiting in the thread.

Additionally this PR specifies which target to use. This avoids confusion of which C library to compile for.