### PR TITLE
Fix temperature measurements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ ncurses = "5.101.0"
 csv = "1.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-subprocess = "0.2.8"
 regex = "1.5.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ ncurses = "5.101.0"
 csv = "1.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-systemstat = "0.1.10"
+subprocess = "0.2.8"
+regex = "1.5.5"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ By default the entire system consumption is measured, however, it is also possib
 ## Table of Contents
 
 - [Installation](#installation)
+  - [Dependencies](#dependencies)
   - [Setup](#setup)
   - [Build & run](#build--run)
   - [Troubleshooting notes](#troubleshooting-notes)
@@ -26,6 +27,10 @@ By default the entire system consumption is measured, however, it is also possib
 ## Installation
 Due to inaccessibility on Windows and MacOS, `raplrs` only runs on Linux systems.
 As such the following steps are only suited for Linux.
+
+### Dependencies
+In addition to the Rust dependencies listed in `Cargo.toml`, rapl.rs has an OS-level dependency used for measuring CPU temperatures: `sensors`.
+This dependency is contained in the `lm-sensors` (Ubuntu) and `lm_sensors` (Arch) package.
 
 ### Setup
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,5 +1,3 @@
-extern crate systemstat;
-
 use crate::common;
 use crate::task;
 use crate::models;


### PR DESCRIPTION
This PR fixes the temperature measurements by using the Linux tool `sensors` instead of the Rust crate we used before.

`sensors` provides current temperatures of all cores present in the CPU:
```
$ sensors | grep Core
Core 0:        +25.0°C  (high = +80.0°C, crit = +100.0°C)
Core 1:        +26.0°C  (high = +80.0°C, crit = +100.0°C)
Core 2:        +24.0°C  (high = +80.0°C, crit = +100.0°C)
Core 3:        +24.0°C  (high = +80.0°C, crit = +100.0°C)
```

These changes will add an average of all core temperatures to the measurements.

![image](https://user-images.githubusercontent.com/36476478/168049856-27a85f5f-9645-4110-80e0-714e0dcd76ee.png)